### PR TITLE
feat: use default caption-based exception handlers

### DIFF
--- a/cloud-minecraft-extras/src/main/java/org/incendo/cloud/minecraft/extras/ComponentCaptionFormatter.java
+++ b/cloud-minecraft-extras/src/main/java/org/incendo/cloud/minecraft/extras/ComponentCaptionFormatter.java
@@ -24,6 +24,7 @@
 package org.incendo.cloud.minecraft.extras;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -200,7 +201,7 @@ public interface ComponentCaptionFormatter<C> extends CaptionFormatter<C, Compon
                 final @NonNull Caption captionKey,
                 final @NonNull C recipient,
                 final @NonNull String caption,
-                final @NonNull CaptionVariable @NonNull... variables
+                final @NonNull Collection<@NonNull CaptionVariable> variables
         ) {
             final Map<String, String> replacements = new HashMap<>();
             for (final CaptionVariable variable : variables) {
@@ -229,7 +230,7 @@ public interface ComponentCaptionFormatter<C> extends CaptionFormatter<C, Compon
                 final @NonNull Caption captionKey,
                 final @NonNull C recipient,
                 final @NonNull String caption,
-                final @NonNull CaptionVariable @NonNull... variables
+                final @NonNull Collection<@NonNull CaptionVariable> variables
         ) {
             return this.mapper.mapComponent(captionKey, caption, recipient);
         }

--- a/cloud-minecraft-extras/src/main/java/org/incendo/cloud/minecraft/extras/MinecraftExceptionHandler.java
+++ b/cloud-minecraft-extras/src/main/java/org/incendo/cloud/minecraft/extras/MinecraftExceptionHandler.java
@@ -48,6 +48,7 @@ import org.incendo.cloud.exception.InvalidCommandSenderException;
 import org.incendo.cloud.exception.InvalidSyntaxException;
 import org.incendo.cloud.exception.NoPermissionException;
 import org.incendo.cloud.exception.handling.ExceptionContext;
+import org.incendo.cloud.util.TypeUtils;
 
 import static net.kyori.adventure.text.Component.newline;
 import static net.kyori.adventure.text.Component.text;
@@ -94,7 +95,7 @@ public final class MinecraftExceptionHandler<C> {
     public static <C> Function<ExceptionContext<C, InvalidCommandSenderException>, Component> createDefaultInvalidSenderHandler() {
         return ctx -> text("Invalid command sender. You must be of type ", NamedTextColor.RED)
                 .append(text(
-                        ctx.exception().requiredSender().getSimpleName(),
+                        TypeUtils.simpleName(ctx.exception().requiredSender()),
                         NamedTextColor.GRAY
                 ));
     }

--- a/cloud-minecraft-extras/src/main/java/org/incendo/cloud/minecraft/extras/MiniMessageComponentCaptionFormatter.java
+++ b/cloud-minecraft-extras/src/main/java/org/incendo/cloud/minecraft/extras/MiniMessageComponentCaptionFormatter.java
@@ -23,6 +23,7 @@
 //
 package org.incendo.cloud.minecraft.extras;
 
+import java.util.Collection;
 import java.util.List;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
@@ -53,7 +54,7 @@ final class MiniMessageComponentCaptionFormatter<C> implements ComponentCaptionF
         final @NonNull Caption captionKey,
         final @NonNull C recipient,
         final @NonNull String caption,
-        final @NonNull CaptionVariable @NonNull... variables
+        final @NonNull Collection<@NonNull CaptionVariable> variables
     ) {
         final TagResolver.Builder builder = TagResolver.builder();
         builder.resolvers(this.extraResolvers);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ ktlint = "0.50.0"
 errorprone = "2.24.1"
 run-task = "2.2.2"
 
-cloudCore = "2.0.0-beta.1"
+cloudCore = "2.0.0-SNAPSHOT"
 
 immutables = "2.10.0"
 


### PR DESCRIPTION
This removes the platform-specific styling from the messages, but it makes them translatable and consistent across all implementations. Better styling should be handled by something like minecraft-extras.

This PR does not switch MinecraftExceptionHandler over to the captions. This should be addressed in a separate PR.