### PR TITLE
fix(bukkit): create registry ResourceKey directly

### DIFF
--- a/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/internal/BukkitBrigadierMapper.java
+++ b/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/internal/BukkitBrigadierMapper.java
@@ -142,7 +142,7 @@ public final class BukkitBrigadierMapper<C> {
         final @NonNull String registryName
     ) {
         this.mapNMS(parserType, "resource_key", type -> (ArgumentType<?>) type.getDeclaredConstructors()[0]
-            .newInstance(RegistryReflection.registryKey(RegistryReflection.registryByName(registryName))));
+            .newInstance(RegistryReflection.registryKey(registryName)));
     }
 
     /**

--- a/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/internal/MinecraftArgumentTypes.java
+++ b/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/internal/MinecraftArgumentTypes.java
@@ -82,7 +82,7 @@ public final class MinecraftArgumentTypes {
         private final Map<?, ?> byClassMap;
 
         private ArgumentTypeGetterImpl() {
-            this.argumentRegistry = Suppliers.memoize(() -> RegistryReflection.registryByName("command_argument_type"));
+            this.argumentRegistry = Suppliers.memoize(() -> RegistryReflection.builtInRegistryByName("command_argument_type"));
             try {
                 final Field declaredField = CraftBukkitReflection.needMCClass("commands.synchronization.ArgumentTypeInfos")
                         .getDeclaredFields()[0];

--- a/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/parser/BlockPredicateParser.java
+++ b/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/parser/BlockPredicateParser.java
@@ -205,7 +205,7 @@ public final class BlockPredicateParser<C> implements ArgumentParser.FutureArgum
                 if (GET_TAG_REGISTRY_METHOD != null) {
                     obj = GET_TAG_REGISTRY_METHOD.invoke(server);
                 } else {
-                    obj = RegistryReflection.registryByName("block");
+                    obj = RegistryReflection.builtInRegistryByName("block");
                 }
                 Objects.requireNonNull(CREATE_PREDICATE_METHOD, "create on BlockPredicateArgument$Result");
                 final Predicate<Object> predicate = (Predicate<Object>) CREATE_PREDICATE_METHOD.invoke(result, obj);

--- a/examples/example-bukkit/src/main/java/org/incendo/cloud/examples/bukkit/builder/BuilderExample.java
+++ b/examples/example-bukkit/src/main/java/org/incendo/cloud/examples/bukkit/builder/BuilderExample.java
@@ -45,6 +45,7 @@ import org.incendo.cloud.examples.bukkit.builder.feature.RegexExample;
 import org.incendo.cloud.examples.bukkit.builder.feature.StringArrayExample;
 import org.incendo.cloud.examples.bukkit.builder.feature.minecraft.BlockPredicateExample;
 import org.incendo.cloud.examples.bukkit.builder.feature.minecraft.ComponentExample;
+import org.incendo.cloud.examples.bukkit.builder.feature.minecraft.EnchantmentExample;
 import org.incendo.cloud.examples.bukkit.builder.feature.minecraft.ItemStackExample;
 import org.incendo.cloud.examples.bukkit.builder.feature.minecraft.ItemStackPredicateExample;
 import org.incendo.cloud.examples.bukkit.builder.feature.minecraft.NamespacedKeyExample;
@@ -70,6 +71,7 @@ public final class BuilderExample {
             new RegexExample(),
             new StringArrayExample(),
             // Minecraft-specific features
+            new EnchantmentExample(),
             new ItemStackExample(),
             new SelectorExample(),
             new TextColorExample(),

--- a/examples/example-bukkit/src/main/java/org/incendo/cloud/examples/bukkit/builder/feature/minecraft/EnchantmentExample.java
+++ b/examples/example-bukkit/src/main/java/org/incendo/cloud/examples/bukkit/builder/feature/minecraft/EnchantmentExample.java
@@ -1,0 +1,29 @@
+package org.incendo.cloud.examples.bukkit.builder.feature.minecraft;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.enchantments.Enchantment;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.incendo.cloud.bukkit.BukkitCommandManager;
+import org.incendo.cloud.examples.bukkit.ExamplePlugin;
+import org.incendo.cloud.examples.bukkit.builder.BuilderFeature;
+
+import static org.incendo.cloud.bukkit.parser.EnchantmentParser.enchantmentParser;
+
+public class EnchantmentExample implements BuilderFeature {
+
+    @Override
+    public void registerFeature(
+        final @NonNull ExamplePlugin examplePlugin,
+        final @NonNull BukkitCommandManager<CommandSender> manager
+    ) {
+        manager.command(
+            manager.commandBuilder("builder")
+                .literal("enchantment")
+                .required("enchant", enchantmentParser())
+                .handler(ctx -> {
+                    final Enchantment enchantment = ctx.get("enchant");
+                    ctx.sender().sendMessage("The enchant you typed is '" + enchantment.getKey() + "'.");
+                })
+        );
+    }
+}

--- a/examples/example-bukkit/src/main/java/org/incendo/cloud/examples/bukkit/builder/feature/minecraft/EnchantmentExample.java
+++ b/examples/example-bukkit/src/main/java/org/incendo/cloud/examples/bukkit/builder/feature/minecraft/EnchantmentExample.java
@@ -1,3 +1,26 @@
+//
+// MIT License
+//
+// Copyright (c) 2024 Incendo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
 package org.incendo.cloud.examples.bukkit.builder.feature.minecraft;
 
 import org.bukkit.command.CommandSender;
@@ -9,7 +32,10 @@ import org.incendo.cloud.examples.bukkit.builder.BuilderFeature;
 
 import static org.incendo.cloud.bukkit.parser.EnchantmentParser.enchantmentParser;
 
-public class EnchantmentExample implements BuilderFeature {
+/**
+ * Example showcasing the enchantment parser.
+ */
+public final class EnchantmentExample implements BuilderFeature {
 
     @Override
     public void registerFeature(


### PR DESCRIPTION
Previously they were fetched from registry instances which are harder to obtain. Now it just creates them using the static methods available on ResourceKey.

Added an example command that uses the parser in question to show it now works.

Fixes https://github.com/Incendo/cloud-minecraft/issues/95