### PR TITLE
define JPMS module names

### DIFF
--- a/gradle/build-logic/src/main/kotlin/conventions.base.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/conventions.base.gradle.kts
@@ -38,3 +38,11 @@ dependencies {
 
 /* Disable checkstyle on tests */
 gradle.startParameter.excludedTaskNames.add("checkstyleTest")
+
+tasks {
+    jar {
+        manifest {
+            attributes("Automatic-Module-Name" to "%s.%s".format(project.group, project.name.replace('-', '.')))
+        }
+    }
+}


### PR DESCRIPTION
_This change is similar to https://github.com/Incendo/cloud/pull/787_

## Summary

The goal of this change is to encourage Gradle to put the framework's Jar files in the module path instead of the classpath. For that, we need to explicitly define the `Automatic-Module-Name` attribute in the `MANIFEST.MF` files in framework's Jar files (source: https://docs.gradle.org/current/userguide/java_library_plugin.html#using_libraries_that_are_not_modules).

The newly added attribute follows this format: `<groupId>.<moduleName>` (e.g. `org.incendo.cloud.paper`).

Details about this change can be found here: https://github.com/Incendo/cloud/issues/785.

## Impact

There is no impact nor on maintainer side nor or consumer one not relying on JPMS.

For the ones already relying on JPMS (e.g. Maven users), they will just have to adapt the references in their `module-info.java` files as follow:

From:
```java
module my.module {
  [...]
  requires cloud.paper;
  [...]
}
```

To:
```java
module my.module {
  [...]
  requires org.incendo.cloud.paper;
  [...]
}
```