### PR TITLE
Add dependency on BOM to all published modules (except bom itself)

### DIFF
--- a/gradle/build-logic/src/main/kotlin/conventions.publishing.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/conventions.publishing.gradle.kts
@@ -5,6 +5,12 @@ plugins {
     id("org.incendo.cloud-build-logic.publishing")
 }
 
+if (!name.endsWith("-bom")) {
+    dependencies {
+        JavaPlugin.API_CONFIGURATION_NAME(platform(project(":cloud-minecraft-bom")))
+    }
+}
+
 indra {
     github("Incendo", "cloud-minecraft") {
         ci(true)


### PR DESCRIPTION
See https://blog.gradle.org/alignment-with-gradle-module-metadata