### PR TITLE
fix: resolve warnings on newer paper

### DIFF
--- a/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/CloudBukkitListener.java
+++ b/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/CloudBukkitListener.java
@@ -26,7 +26,7 @@ package org.incendo.cloud.bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerSpawnLocationEvent;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -40,7 +40,7 @@ final class CloudBukkitListener<C> implements Listener {
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    void onPlayerLogin(final @NonNull PlayerLoginEvent event) {
+    void onPlayerLogin(final @NonNull PlayerSpawnLocationEvent event) {
         /* If the server is brigadier-capable, any registration after players
            have joined (and been sent a command tree) is unsafe.
            Bukkit's PlayerJoinEvent is called just after the command tree is sent,


### PR DESCRIPTION
Paper has deprecated the login event. This replaces it. More context here: https://canary.discord.com/channels/766366162388123678/766381452639731722/1389323022397346062