### PR TITLE
[Fixes #129] Fix warning about using the PlayerSpawnLocationEvent on Paper

### DIFF
--- a/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/CloudBukkitListener.java
+++ b/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/CloudBukkitListener.java
@@ -26,9 +26,9 @@ package org.incendo.cloud.bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.spigotmc.event.player.PlayerSpawnLocationEvent;
 
 final class CloudBukkitListener<C> implements Listener {
 
@@ -39,11 +39,11 @@ final class CloudBukkitListener<C> implements Listener {
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    void onPlayerLogin(final @NonNull PlayerSpawnLocationEvent event) {
+    void onPlayerLogin(final @NonNull AsyncPlayerPreLoginEvent event) {
         /* If the server is brigadier-capable, any registration after players
            have joined (and been sent a command tree) is unsafe.
            Bukkit's PlayerJoinEvent is called just after the command tree is sent,
-           so we have to perform this state change at PlayerSpawnLocationEvent to lock before that happens. */
+           so we have to perform this state change at AsyncPlayerPreLoginEvent to lock before that happens. */
         this.bukkitCommandManager.lockIfBrigadierCapable();
     }
 


### PR DESCRIPTION
Made use of the single-event registration API of Bukkit to avoid having to add a submodule for paper.

Tested it locally and works without warnings or errors now.

Fixes #129