### PR TITLE
Fix major version parsing for versions 26.1 and above

### DIFF
--- a/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/internal/CraftBukkitReflection.java
+++ b/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/internal/CraftBukkitReflection.java
@@ -65,7 +65,15 @@ public final class CraftBukkitReflection {
             if (Bukkit.getServer() != null) {
                 try {
                     final Method getMinecraftVersion = serverClass.getDeclaredMethod("getMinecraftVersion");
-                    fallbackVersion = Integer.parseInt(getMinecraftVersion.invoke(Bukkit.getServer()).toString().split("\\.")[1]);
+                    String versionString = getMinecraftVersion.invoke(Bukkit.getServer()).toString();
+                    String[] versionParts = versionString.split("\\.");
+                    if (versionParts[0].equalsIgnoreCase("1")) {
+                        // for versions 1.21.11 and below
+                        fallbackVersion = Integer.parseInt(versionParts[1]);
+                    } else {
+                        // for 26.1+
+                        fallbackVersion = Integer.parseInt(versionParts[0]);
+                    }
                 } catch (final Exception ignored) {
                 }
             } else {
@@ -85,7 +93,14 @@ public final class CraftBukkitReflection {
                     }
                     final String versionName = (String) getName.invoke(currentVersion);
                     try {
-                        fallbackVersion = Integer.parseInt(versionName.split("\\.")[1]);
+                        String[] versionParts = versionName.split("\\.");
+                        if (versionParts[0].equalsIgnoreCase("1")) {
+                            // for versions 1.21.11 and below
+                            fallbackVersion = Integer.parseInt(versionParts[1]);
+                        } else {
+                            // for 26.1+
+                            fallbackVersion = Integer.parseInt(versionParts[0]);
+                        }
                     } catch (final Exception ignored) {
                     }
                 } catch (final ReflectiveOperationException e) {

--- a/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/internal/CraftBukkitReflection.java
+++ b/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/internal/CraftBukkitReflection.java
@@ -61,19 +61,11 @@ public final class CraftBukkitReflection {
         final String pkg = serverClass.getPackage().getName();
         final String nmsVersion = pkg.substring(pkg.lastIndexOf(".") + 1);
         if (!nmsVersion.contains("_")) {
-            int fallbackVersion = -1;
+            String versionString = null;
             if (Bukkit.getServer() != null) {
                 try {
                     final Method getMinecraftVersion = serverClass.getDeclaredMethod("getMinecraftVersion");
-                    String versionString = getMinecraftVersion.invoke(Bukkit.getServer()).toString();
-                    String[] versionParts = versionString.split("\\.");
-                    if (versionParts[0].equalsIgnoreCase("1")) {
-                        // for versions 1.21.11 and below
-                        fallbackVersion = Integer.parseInt(versionParts[1]);
-                    } else {
-                        // for 26.1+
-                        fallbackVersion = Integer.parseInt(versionParts[0]);
-                    }
+                    versionString = getMinecraftVersion.invoke(Bukkit.getServer()).toString();
                 } catch (final Exception ignored) {
                 }
             } else {
@@ -91,22 +83,27 @@ public final class CraftBukkitReflection {
                         // ~1.21.6+
                         getName = currentVersion.getClass().getDeclaredMethod("name");
                     }
-                    final String versionName = (String) getName.invoke(currentVersion);
-                    try {
-                        String[] versionParts = versionName.split("\\.");
-                        if (versionParts[0].equalsIgnoreCase("1")) {
-                            // for versions 1.21.11 and below
-                            fallbackVersion = Integer.parseInt(versionParts[1]);
-                        } else {
-                            // for 26.1+
-                            fallbackVersion = Integer.parseInt(versionParts[0]);
-                        }
-                    } catch (final Exception ignored) {
-                    }
+                    versionString = (String) getName.invoke(currentVersion);
                 } catch (final ReflectiveOperationException e) {
                     throw new RuntimeException(e);
                 }
             }
+
+            int fallbackVersion = -1;
+            if (versionString != null) {
+                try {
+                    String[] versionParts = versionString.split("\\.");
+                    if (versionParts[0].equalsIgnoreCase("1")) {
+                        // for versions 1.21.11 and below
+                        fallbackVersion = Integer.parseInt(versionParts[1]);
+                    } else {
+                        // for 26.1+
+                        fallbackVersion = Integer.parseInt(versionParts[0]);
+                    }
+                } catch (Exception ignored) {
+                }
+            }
+
             MAJOR_REVISION = fallbackVersion;
         } else {
             MAJOR_REVISION = Integer.parseInt(nmsVersion.split("_")[1]);


### PR DESCRIPTION
In the new minecraft versions the version string dropped the prefix "1.". This PR fixes the version parsing to make the master version detection work properly.

The parsing code always looks at the second part of the version as major part. Therefore the version string "26.1" would be detected as running on version 1. To fix this I implemented a check that checks if the first part of the version is 1. If this is the case we use the second part as major version, if not we use the first part as major version.

Questions and feedback are appreciated :slightly_smiling_face: 