### PR TITLE
Handle Paper 26.2 shift in NMS->CraftItemStack. 

### DIFF
--- a/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/parser/ItemStackParser.java
+++ b/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/parser/ItemStackParser.java
@@ -161,8 +161,11 @@ public class ItemStackParser<C> implements ArgumentParser.FutureArgumentParser<C
                 CraftBukkitReflection.findMethod(ITEM_INPUT_CLASS, "createItemStack", int.class, boolean.class),
                 CraftBukkitReflection.findMethod(ITEM_INPUT_CLASS, "createItemStack", int.class)
         );
-        private static final Method AS_BUKKIT_COPY_METHOD = CraftBukkitReflection
-                .needMethod(CRAFT_ITEM_STACK_CLASS, "asBukkitCopy", NMS_ITEM_STACK_CLASS);
+        private static final Method AS_BUKKIT_COPY_METHOD = CraftBukkitReflection.firstNonNullOrThrow(
+            () -> "Couldn't find asBukkitCopy or asCraftMirror method on CraftItemStack",
+            CraftBukkitReflection.findMethod(CRAFT_ITEM_STACK_CLASS, "asBukkitCopy", NMS_ITEM_STACK_CLASS),
+            CraftBukkitReflection.findMethod(CRAFT_ITEM_STACK_CLASS, "asCraftMirror", NMS_ITEM_STACK_CLASS)
+        );
         private static final Field ITEM_FIELD = CraftBukkitReflection.firstNonNullOrThrow(
                 () -> "Couldn't find item field on ItemInput",
                 CraftBukkitReflection.findField(ITEM_INPUT_CLASS, "b"),

--- a/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/parser/ItemStackParser.java
+++ b/cloud-bukkit/src/main/java/org/incendo/cloud/bukkit/parser/ItemStackParser.java
@@ -161,7 +161,7 @@ public class ItemStackParser<C> implements ArgumentParser.FutureArgumentParser<C
                 CraftBukkitReflection.findMethod(ITEM_INPUT_CLASS, "createItemStack", int.class, boolean.class),
                 CraftBukkitReflection.findMethod(ITEM_INPUT_CLASS, "createItemStack", int.class)
         );
-        private static final Method AS_BUKKIT_COPY_METHOD = CraftBukkitReflection.firstNonNullOrThrow(
+        private static final Method AS_BUKKIT_STACK_METHOD = CraftBukkitReflection.firstNonNullOrThrow(
             () -> "Couldn't find asBukkitCopy or asCraftMirror method on CraftItemStack",
             CraftBukkitReflection.findMethod(CRAFT_ITEM_STACK_CLASS, "asBukkitCopy", NMS_ITEM_STACK_CLASS),
             CraftBukkitReflection.findMethod(CRAFT_ITEM_STACK_CLASS, "asCraftMirror", NMS_ITEM_STACK_CLASS)
@@ -281,7 +281,7 @@ public class ItemStackParser<C> implements ArgumentParser.FutureArgumentParser<C
                     final Object nmsItemStack = CREATE_ITEM_STACK_METHOD.getParameterCount() == 1
                             ? CREATE_ITEM_STACK_METHOD.invoke(this.itemInput, stackSize)
                             : CREATE_ITEM_STACK_METHOD.invoke(this.itemInput, stackSize, true);
-                    return (ItemStack) AS_BUKKIT_COPY_METHOD.invoke(
+                    return (ItemStack) AS_BUKKIT_STACK_METHOD.invoke(
                             null,
                             nmsItemStack
                     );


### PR DESCRIPTION
Now also looks for the asCraftMirror method which does the same thing.

Fixes #157 for Paper. Tested on Paper 26.1.2 and 26.2.1-rc.2