### PR TITLE
fix: expose Immutables annotations to consumers

### DIFF
--- a/gradle/build-logic/src/main/kotlin/conventions.base.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/conventions.base.gradle.kts
@@ -31,8 +31,9 @@ if (providers.ciBuild.get() && libs.versions.cloudCore.get().endsWith("-SNAPSHOT
 dependencies {
     checkstyle(libs.stylecheck)
     errorprone(libs.errorproneCore)
-    compileOnly(libs.bundles.immutables)
-    annotationProcessor(libs.bundles.immutables)
+    compileOnlyApi(libs.immutablesValueAnnotations)
+    compileOnlyApi(libs.immutablesAnnotate)
+    annotationProcessor(libs.immutablesValue)
 
     testImplementation(libs.jupiterEngine)
     testImplementation(libs.jupiterParams)

--- a/gradle/build-logic/src/main/kotlin/conventions.publishing.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/conventions.publishing.gradle.kts
@@ -29,4 +29,6 @@ indra {
 
 javadocLinks {
     defaultJavadocProvider = "https://www.javadocs.dev/{group}/{name}/{version}"
+    exclude(libs.immutablesValueAnnotations)
+    exclude(libs.immutablesAnnotate)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,8 @@ cloud-bom = { module = "org.incendo:cloud-bom", version.ref = "cloudCore" }
 cloud-core = { module = "org.incendo:cloud-core", version.ref = "cloudCore" }
 cloud-annotations = { module = "org.incendo:cloud-annotations", version.ref = "cloudCore" }
 
-immutables = { group = "org.immutables", name = "value", version.ref = "immutables" }
+immutablesValue = { group = "org.immutables", name = "value", version.ref = "immutables" }
+immutablesValueAnnotations = { group = "org.immutables", name = "value-annotations", version.ref = "immutables" }
 immutablesAnnotate = { group = "org.immutables", name = "annotate", version.ref = "immutables" }
 
 brigadier = { group = "com.mojang", name = "brigadier", version.ref = "brigadier" }
@@ -75,4 +76,3 @@ run-waterfall = { id = "xyz.jpenilla.run-waterfall", version.ref = "run-task" }
 shadow = { id = "com.gradleup.shadow", version = "9.4.2" }
 
 [bundles]
-immutables = ["immutables", "immutablesAnnotate"]


### PR DESCRIPTION
Publish the lightweight value and annotate artifacts on consumers' compile classpaths while keeping the full Immutables processor isolated to annotation processing.

Exclude these artifacts from external Javadoc linking because they do not publish the required element-list or package-list files.

Fixes missing annotation warnings for consumers.

Ports Incendo/cloud#817.